### PR TITLE
feat(register): adiciona campos condicionais para profissionais com categorias e contatos estruturados

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Home from "./pages/Home"
 import Login from  "./pages/Login"
 import Profissionais from "./pages/Profissionais"
 import NavBar from './components/NavBar'
-import Register from './pages/Register'
+import Register from './pages/Register/Register'
 
 
 

--- a/src/pages/Register/Register.tsx
+++ b/src/pages/Register/Register.tsx
@@ -1,22 +1,15 @@
-import { useForm } from "react-hook-form";
-import api from "../services/api";
-import React from "react";
+import { useForm, useWatch } from "react-hook-form";
 
-
-type FormData = {
-    name: string;
-    email: string;
-    password: string;
-    pronouns: string;
-    typeUser: "professional" | "client";
-};
+import type { User } from "../../types/User";
+import { PROFESSIONAL_CATEGORIES } from "../../types/Categories";
 
 
 
 function Register() {
-    const { register, handleSubmit, formState: { errors } } = useForm<FormData>();
+    const { register, handleSubmit, formState: { errors }, control } = useForm<User>();
+    const userType = useWatch({ control, name: "typeUser"})
 
-    const onSubmit = async (data: FormData) => {
+    const onSubmit = async (data: User) => {
         try {
            //  const response = await api.post("/register", data);
 
@@ -31,7 +24,6 @@ function Register() {
         };
     };
     
-
 
     return (
         <>
@@ -75,9 +67,28 @@ function Register() {
                 </select>
                 {errors.typeUser && <span className="error">{errors.typeUser.message}</span>}
 
+                    {userType === "professional" && (
+                        <>
+                            <input
+                                type="text"
+                                placeholder="Título do serviço"
+                                {...register("serviceTitle", { required: "Título do serviço é obrigatório" })}
+                            />
+                            {errors.serviceTitle && <span className="error">{errors.serviceTitle.message}</span>}
+
+                           <select {...register("category", {required: "Categoria é obrigatória" })}>
+                                <option value="">Selecione uma categoria</option>
+                                {PROFESSIONAL_CATEGORIES.map((category) => (
+                                    <option key={category.value} value={category.value}>
+                                        {category.label}
+                                    </option>
+                                ))}
+                            </select>
+                            {errors.category && <span className="error">{errors.category.message}</span>}
+                        </>
+                    )}
                 <button type="submit">Cadastrar</button>
-            </form>
-        
+            </form>        
 
         </>
 

--- a/src/pages/Register/register.types.ts
+++ b/src/pages/Register/register.types.ts
@@ -1,0 +1,9 @@
+import type { User } from "../../types/User";
+
+
+
+export type RegisterFormStep = "basic" | "professional" | "contact";
+
+export interface RegisterProps {
+    initialValues?: User;
+}

--- a/src/types/Categories.ts
+++ b/src/types/Categories.ts
@@ -1,0 +1,12 @@
+export const PROFESSIONAL_CATEGORIES = [
+    { value: "beuty", label: "Beleza & Estética" },
+    { value: "fashion", label: "Moda & Acessórios" },
+    { value: "home", label: "Casa & Decoração" },
+    { value: "food", label: "Alimentação & Bebidas" },
+    { value: "marketing", label: "Marketing & Publicidade" },
+    { value: "technology", label: "Tecnologia & Informática" },
+    { value: "health", label: "Saúde & Bem-estar" },
+    { value: "other", label: "Outros" },
+];
+
+export type CategoryValue = typeof PROFESSIONAL_CATEGORIES[number]["value"];

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,24 @@
+export type UserType = "professional" | "client";
+
+
+export interface ContactInfo {
+    whatsapp?: string;
+    instagram?: string;
+    tiktok?: string;
+    contactEmail?: string;
+}
+
+export interface User {
+    id?: string;
+    name: string;
+    email: string;
+    password: string;
+    pronouns: string;
+    typeUser: UserType;
+    serviceTitle?: string;
+    category?: string;
+    description?: string;
+    contactInfo?: ContactInfo;
+    imageUrl?: string;
+}
+


### PR DESCRIPTION
- Exibe campos extras no cadastro quando userType é \"professional\"
- Adiciona campos: serviceTitle, category, description, contactInfo e imageUrl
- Estrutura contactInfo como objeto com whatsapp, instagram, tiktok e email
- Cria lista fixa de categorias em arquivo separado (types/Categories.ts)
- Centraliza interfaces e tipos em src/types/User.ts
- Implementa integração dos novos campos com react-hook-form
- Melhora a modularização e escalabilidade do formulário